### PR TITLE
feat: add the ability to pass an array of paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,15 @@ projects ESLint configuration.
 
 You can also pass an array of paths.
 
-  ```javascript
-  {
+```javascript
+{
   type: "eslint",
   path: [
-      "src/component/{{pascalCase name}}.js",
-      "src/component/{{pascalCase name}}.test.js",
-    ],
-  }
-  ```
+    "src/component/{{pascalCase name}}.js",
+    "src/component/{{pascalCase name}}.test.js",
+  ],
+}
+```
 
 ## Prettier Support
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ projects ESLint configuration.
 }
 ```
 
+You can also pass an array of paths.
+
+  ```javascript
+  {
+  type: "eslint",
+  path: [
+      "src/component/{{pascalCase name}}.js",
+      "src/component/{{pascalCase name}}.test.js",
+    ],
+  }
+  ```
+
 ## Prettier Support
 
 In order to automatically format your code with Prettier as well, you have to

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plop-action-eslint",
   "description": "Use ESLint to format generated code with plop.js",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "private": true,
   "author": {
     "name": "Stefan Natter",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plop-action-eslint",
   "description": "Use ESLint to format generated code with plop.js",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "author": {
     "name": "Stefan Natter",

--- a/packages/plop-action-eslint/src/index.ts
+++ b/packages/plop-action-eslint/src/index.ts
@@ -13,10 +13,15 @@ const eslintAction: CustomActionFunction = async (
   plopInstance,
 ) => {
   if (config && config.path && plopInstance) {
-    const filePath = plopInstance.renderString(config.path, answers)
+    const stringsToRender = Array.isArray(config.path)
+      ? config.path
+      : [config.path]
+    const filePaths = stringsToRender.map(path =>
+      plopInstance.renderString(path, answers),
+    )
 
     const eslint = new ESLint({ fix: true })
-    const results = await eslint.lintFiles(filePath)
+    const results = await eslint.lintFiles(filePaths)
 
     await ESLint.outputFixes(results)
 


### PR DESCRIPTION
<!--

Please submit all PRs to the `main` branch unless they are specific to current
release.

-->

# Notes

## What I did

Added the ability to pass the array of paths to the action.

## How to test

Assign the array of strings (paths) to action's `path` property and verify all of the listed paths are linted.


## Related Issues

Resolves [#3](https://github.com/natterstefan/plop-action-eslint/issues/3)