### PR TITLE
chore: extend plop peerDependency to allow v4

### DIFF
--- a/packages/plop-action-eslint/package.json
+++ b/packages/plop-action-eslint/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "eslint": "^8.19.0",
-    "plop": "^3.1.2"
+    "plop": "^3.1.2 || ^4.0.0"
   },
   "dependencies": {
     "tslib": "^2.6.2"


### PR DESCRIPTION
# Notes

Updates the `peerDependency` for `plop` to allow v4.

## How to test

Install in a project using v4 of plop.